### PR TITLE
Fixes an issue where the volume can get stuck at max

### DIFF
--- a/FarmIt2_Core.lua
+++ b/FarmIt2_Core.lua
@@ -552,12 +552,12 @@ function FI_Alert( message, color, sound, throttle, item, louder )
             local pre = GetCVar("Sound_MasterVolume");
             SetCVar("Sound_MasterVolume", 1.0);
             C_Timer.After(6, function()
-              SetCVar("Sound_MasterVolume", pre)
+              SetCVar("Sound_MasterVolume", pre);
               FI_LOUD_ACTIVE = false;
             end);
         end
         if louder and Rarity and item then
-            Rarity:ShowFoundAlert(item, 1)
+            Rarity:ShowFoundAlert(item, 1);
         else
             PlaySound(sound);
         end

--- a/FarmIt2_Core.lua
+++ b/FarmIt2_Core.lua
@@ -547,10 +547,14 @@ function FI_Alert( message, color, sound, throttle, item, louder )
     else
       -- audio
       if sound and FI_SV_CONFIG.Alerts.sound then
-        if louder then
+        if louder and not FI_LOUD_ACTIVE then
+            FI_LOUD_ACTIVE = true;
             local pre = GetCVar("Sound_MasterVolume");
             SetCVar("Sound_MasterVolume", 1.0);
-            C_Timer.After(6, function() SetCVar("Sound_MasterVolume", pre) end);
+            C_Timer.After(6, function()
+              SetCVar("Sound_MasterVolume", pre)
+              FI_LOUD_ACTIVE = false;
+            end);
         end
         if louder and Rarity and item then
             Rarity:ShowFoundAlert(item, 1)

--- a/FarmIt2_Data.lua
+++ b/FarmIt2_Data.lua
@@ -23,10 +23,10 @@ FI_MOVING = false; --alters behavior of some functions
 FI_SPAM_LIMIT = 1; --seconds
 FI_MIN_UPTIME = 10; --seconds
 FI_ALERT_TS = 0; --timestamp
+FI_LOUD_ACTIVE = false; --flag to track if a loud alert is active, so the volume doesn't get stuck at max
 
 FI_ADDON_LOADED = false;
 FI_CURRENCY_LOADED = false;
-FI_BAGS_LOADED = false;
 
 -- FarmIt's clipboard
 FI_SELECTED = false;


### PR DESCRIPTION
If multiple loud alerts were played in quick succession, subsequent calls could see their `pre` volume at 1.0 instead of the user-chosen value.

Added a global to track when the timer is active; as a trade off, I removed an unused global.